### PR TITLE
El tamaño de letra crece de acuerdo al ancho del dispositibo

### DIFF
--- a/style.css
+++ b/style.css
@@ -19,7 +19,7 @@
 }
 
 html {
-    font-size: 62.5%;
+    font-size: clamp(0.62rem, 0.425rem + 1vw, 0.9rem);
     font-family: var(--icceberg);
 
 }


### PR DESCRIPTION
Hola, hacer esto puede resultar útil a la hora de incrementar el tamaño de las letras segun el ancho del dispositivo se vuelve más grande:

```css
html {
    font-size: clamp(0.62rem, 0.425rem + 1vw, 0.9rem);
}
```
En la funcion `clamp()`, `0.62rem` (9.92px) define el tamaño minimo y `0.9rem` (14.4px) define el tamaño maximo.

Esta tecnica evita que hagamos cosas como estas:
```css
@media (min-width: 30em) {
  html {
    font-size: 125%;
  }
}

@media (min-width: 40em) {
  html {
    font-size: 150%;
  }
}

@media (min-width: 50em) {
  html {
    font-size: 175%;
  }
}

@media (min-width: 60em) {
  html {
    font-size: 200%;
  }
}
```
[Aquí se esplica los que la funcion `clamp()` hace](https://web-dev.translate.goog/learn/design/typography/?_x_tr_sl=en&_x_tr_tl=es&_x_tr_hl=es&_x_tr_pto=wapp#scaling-text)